### PR TITLE
Use vim log levels instead of custom implementation

### DIFF
--- a/lua/sonarqube/cmds/install.lua
+++ b/lua/sonarqube/cmds/install.lua
@@ -16,7 +16,7 @@ local unzip_vsix = function()
     vim.system({ "unzip", "-o", vsix_path, "-d", sonarqube_dir }, {}, function(result)
         vim.schedule(function()
             if result.code ~= 0 then
-                vim.notify("Unable to unpack SonarQube LSP", "ERROR")
+                vim.notify("Unable to unpack SonarQube LSP", vim.log.levels.ERROR)
                 return
             end
 
@@ -35,7 +35,10 @@ local download_vsix = function(releases)
     vim.system({ "curl", "-L", "-o", vsix_path, url }, {}, function(result)
         vim.schedule(function()
             if result.code ~= 0 then
-                vim.notify("Unable to download SonarQube LSP: Failed to download vsix", "ERROR")
+                vim.notify(
+                    "Unable to download SonarQube LSP: Failed to download vsix",
+                    vim.log.levels.ERROR
+                )
                 return
             end
 
@@ -46,12 +49,12 @@ end
 
 local install_lsp = function()
     if vim.fn.exepath("curl") == not_found then
-        vim.notify("Unable to Install SonarQube LSP: curl command not found", "ERROR")
+        vim.notify("Unable to Install SonarQube LSP: curl command not found", vim.log.levels.ERROR)
         return
     end
 
     if vim.fn.exepath("unzip") == not_found then
-        vim.notify("Unable to Install SonarQube LSP: unzip command not found", "ERROR")
+        vim.notify("Unable to Install SonarQube LSP: unzip command not found", vim.log.levels.ERROR)
         return
     end
 
@@ -64,7 +67,10 @@ local install_lsp = function()
     }, {}, function(result)
         vim.schedule(function()
             if result.code ~= 0 then
-                vim.notify("Unable to download SonarQube LSP: Failed to get releases", "ERROR")
+                vim.notify(
+                    "Unable to download SonarQube LSP: Failed to get releases",
+                    vim.log.levels.ERROR
+                )
                 return
             end
 

--- a/lua/sonarqube/java/init.lua
+++ b/lua/sonarqube/java/init.lua
@@ -38,7 +38,7 @@ local jdtls_java_project_getSettings = function(dependencies, settings)
         },
     }, function(err, res)
         if err ~= nil then
-            vim.notify("Failed to get java project settings", "WARN")
+            vim.notify("Failed to get java project settings", vim.log.levels.WARN)
             coroutine.resume(dependencies.co)
             return
         end
@@ -64,7 +64,7 @@ local jdtls_java_project_isTest = function(dependencies, settings)
         arguments = { dependencies.uri },
     }, function(err, res)
         if err ~= nil then
-            vim.notify("Failed to determine if buffer is a test file", "WARN")
+            vim.notify("Failed to determine if buffer is a test file", vim.log.levels.WARN)
             coroutine.resume(dependencies.co)
             return
         end

--- a/lua/sonarqube/lsp/server.lua
+++ b/lua/sonarqube/lsp/server.lua
@@ -17,14 +17,6 @@ local M = {
     },
 }
 
-local log_levels = {
-    DEBUG = 1,
-    INFO = 2,
-    WARN = 3,
-    ERROR = 4,
-    OFF = 10,
-}
-
 M.handlers["sonarlint/canShowMissingRequirementsNotification"] = function()
     return false
 end
@@ -98,7 +90,7 @@ local log_message = function(message, log_level)
     local first_space = message:find(" ")
     local lvl = message:sub(2, first_space - 1):upper()
 
-    if log_levels[lvl] >= log_levels[log_level:upper()] then
+    if vim.log.levels[lvl] >= vim.log.levels[log_level:upper()] then
         local closing_bracket = message:find("]")
         vim.notify(message:sub(closing_bracket + 2), lvl:lower())
     end

--- a/lua/sonarqube/rules/init.lua
+++ b/lua/sonarqube/rules/init.lua
@@ -12,13 +12,13 @@ end
 M.list_all_rules = function()
     local client = vim.lsp.get_clients({ name = "sonarqube" })
     if #client == 0 then
-        vim.notify("Failed to run SonarQubeListAllRules: SonarQube LSP is not running", "ERROR")
+        vim.notify("Failed to run SonarQubeListAllRules: SonarQube LSP is not running", vim.log.levels.ERROR)
         return
     end
 
     client[1].request("sonarlint/listAllRules", {}, function(err, res)
         if err ~= nil then
-            vim.notify("Failed to run SonarQubeListAllRules: SonarQube LSP returned error", "ERROR")
+            vim.notify("Failed to run SonarQubeListAllRules: SonarQube LSP returned error", vim.log.levels.ERROR)
             return
         end
 


### PR DESCRIPTION
# Description
The current notifications are using a string for the log level. The `window/logMessage` also uses a custom table for log levels that basically re-implements the built-in vim table `vim.log.levels`.

# Notes
- Simply remove all references to the log level strings, and the custom table in favor of `vim.log.levels`