### PR TITLE
Implement show rule description to use the browser by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ require('sonarqube').setup({
         },
         -- capabilities = require("cmp_nvim_lsp").default_capabilities(),
         log_level = "OFF",
+        handlers = {
+            -- Custom handler to show rule description
+            -- The `res` argument contains various keys containing html that can be rendered in your favourite neovim html plugin 
+            -- Alternatively, open the rule in the browser using your favourite sonarqube rule website (example below)
+            ["sonarlint/showRuleDescription"] = function(err, res, ctx, cfg)
+                local uri = "https://rules.sonarsource.com/%s/RSPEC-%s"
+                local lang = res.languageKey
+                local spec = string.match(res.key, "S(%d+)")
+                vim.ui.open(string.format(uri, lang, spec))
+            end,
+        },
     },
     rules = {
         enabled = true,

--- a/lua/sonarqube/lsp/server.lua
+++ b/lua/sonarqube/lsp/server.lua
@@ -51,7 +51,10 @@ M.handlers["sonarlint/filterOutExcludedFiles"] = function(_, params, _, _)
     return params
 end
 
-M.handlers["sonarlint/showRuleDescription"] = function(_, params, _, _) end
+M.handlers["sonarlint/showRuleDescription"] = function(_, req, _, _)
+    local uri = "https://next.sonarqube.com/sonarqube/coding_rules?q=%s&open=%s"
+    vim.ui.open(string.format(uri, req.key, req.key))
+end
 
 M.handlers["sonarlint/needCompilationDatabase"] = function(_, _, ctx)
     return nil
@@ -114,6 +117,14 @@ M.setup = function(opts)
     M.register_handler("window/logMessage", function(_, req)
         log_message(req.message, opts.log_level)
     end)
+
+    if opts.handlers ~= nil then
+        local handler = "sonarlint/showRuleDescription"
+        local fn = opts.handlers[handler]
+        if fn ~= nil and type(fn) == "function" then
+            M.register_handler(handler, fn)
+        end
+    end
 end
 
 return M


### PR DESCRIPTION
# Notes
- Create a default implementation of `sonarlint/showRuleDescription` to open in the browser
- Create configuration to allow a custom implementation of the handler